### PR TITLE
feat(map): interactive map layout with recommendations panel

### DIFF
--- a/apps/web/src/app/(app)/(map)/layout.tsx
+++ b/apps/web/src/app/(app)/(map)/layout.tsx
@@ -1,16 +1,9 @@
 import React from "react";
 
-export default function MapLayout({children}: {children: React.ReactNode}){
-    return(
-        <main
-            className="
-            w-full
-            p-0
-            overflow-hidden
-            h-[calc(100dvh-56px)]
-            "
-        >
-            {children}
-        </main>
-    );
+export default function MapLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <main className="h-dvh w-full overflow-hidden">
+      {children}
+    </main>
+  );
 }

--- a/apps/web/src/app/(app)/(map)/map/page.tsx
+++ b/apps/web/src/app/(app)/(map)/map/page.tsx
@@ -1,34 +1,84 @@
-export default function MapPage(){
-    return (
-        <div className="h-full w-full">
-            <div className="flex h-full w-full">
-                <section className="flex-1 bg-neutral-100">
-                    <div className="h-full w-full flex items-center justify-center">
-                        <div className="text-center">
-                            <h1 className="text-xl font-semibold">Map Area1</h1>
-                            <p className="mt-2 text-fg">
-                                지도 영역
-                            </p>
-                        </div>
-                    </div>
-                </section>
-                <aside className="hidden md:block w-[360px] border-l bg-bg">
-                    <div className="h-full p-4 overflow-auto">
-                        <h2 className="text-lg font-semibold">Recommendations</h2>
-                        <p className="mt-2 text-sm text-fg">
-                            점수 높은 나라 목록/필터/정렬
-                        </p>
-                        <div className="mt-4 space-y-3">
-                            {["Australia", "Canada", "New Zealand", "Germany"].map((name) => (
-                                <div key={name} className="rounded-xl border p-3 hover:bg-neutral-50">
-                                    <div className="font-medium">{name}</div>
-                                    <div className="text-sm text-fg">Score: --</div>
-                                </div>
-                            ))}
-                        </div>
-                    </div>
-                </aside>
+"use client";
+
+import { useMemo, useState } from "react";
+import RecommendationsPanel, {
+  RecommendationItem,
+} from "@/shared/components/RecommendationsPanel";
+
+export default function MapPage() {
+  // desktop panel state
+  const [desktopWidth, setDesktopWidth] = useState(360);
+  const [desktopCollapsed, setDesktopCollapsed] = useState(false);
+
+  // mobile sheet state (px). 0 = hidden
+  const [mobileHeight, setMobileHeight] = useState(0);
+
+  const items: RecommendationItem[] = useMemo(
+    () => [
+      { id: "au", country: "Australia", score: 82 },
+      { id: "ca", country: "Canada", score: 74 },
+      { id: "nz", country: "New Zealand", score: 71 },
+      { id: "de", country: "Germany", score: 61 },
+      { id: "jp", country: "Japan", score: 58 },
+    ],
+    []
+  );
+
+  // Map should be “pushed” on mobile when bottom sheet is open:
+  const mapPaddingBottom = Math.max(0, mobileHeight);
+
+  return (
+    <div className="relative h-full w-full top-20 right-5">
+      {/* Desktop layout: map + right docked panel (pushes map) */}
+      <div className="hidden h-full w-full md:flex">
+        <section className="relative flex-1 bg-neutral-100">
+          <div className="absolute inset-0">
+            <div className="h-full w-full flex items-center justify-center">
+              <div className="text-center">
+                <h1 className="text-xl font-semibold">Map Area</h1>
+                <p className="mt-2 text-fg">지도 영역</p>
+              </div>
             </div>
-        </div>
-    )
+          </div>
+        </section>
+
+        <RecommendationsPanel
+          items={items}
+          desktopWidth={desktopWidth}
+          setDesktopWidth={setDesktopWidth}
+          desktopCollapsed={desktopCollapsed}
+          setDesktopCollapsed={setDesktopCollapsed}
+          mobileHeight={mobileHeight}
+          setMobileHeight={setMobileHeight}
+        />
+      </div>
+
+      {/* Mobile layout: map full + bottom sheet pushes map via padding */}
+      <div className="md:hidden h-full w-full">
+        <section
+          className="relative h-full w-full bg-neutral-100"
+          style={{ paddingBottom: mapPaddingBottom }}
+        >
+          <div className="absolute inset-0">
+            <div className="h-full w-full flex items-center justify-center">
+              <div className="text-center">
+                <h1 className="text-xl font-semibold">Map Area</h1>
+                <p className="mt-2 text-fg">지도 영역</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <RecommendationsPanel
+          items={items}
+          desktopWidth={desktopWidth}
+          setDesktopWidth={setDesktopWidth}
+          desktopCollapsed={desktopCollapsed}
+          setDesktopCollapsed={setDesktopCollapsed}
+          mobileHeight={mobileHeight}
+          setMobileHeight={setMobileHeight}
+        />
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/app/(main)/page.tsx
+++ b/apps/web/src/app/(main)/page.tsx
@@ -8,104 +8,104 @@ const montserratAlternates = Montserrat_Alternates({
 });
 
 export default function MainPage() {
-  return (
-    <main className="min-h-screen bg-bg text-fg flex flex-col">
-      {/* Top bar */}
-      <header className="w-full border-b border-[rgb(var(--border))]">
-        <div className="mx-auto flex w-full max-w-5xl items-center justify-between px-5 py-3">
-          {/* Logo / brand */}
-          <div className="flex items-center gap-3">
-            <div className="h-9 w-9 rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))]" />
-            <span
-              className={`${montserratAlternates.className} text-lg font-semibold tracking-tight`}
-            >
-              whalley
-            </span>
-          </div>
+	return (
+		<main className="min-h-screen bg-bg text-fg flex flex-col">
+		{/* Top bar */}
+		<header className="w-full border-b border-[rgb(var(--border))]">
+			<div className="mx-auto flex w-full max-w-5xl items-center justify-between px-5 py-3">
+			{/* Logo / brand */}
+			<div className="flex items-center gap-3">
+				<div className="h-9 w-9 rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))]" />
+				<span
+				className={`${montserratAlternates.className} text-lg font-semibold tracking-tight`}
+				>
+				whalley
+				</span>
+			</div>
 
-          {/* menu */}
-          <div className="flex items-center gap-2">
-            <button
-              className="rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-sm transition hover:bg-[rgb(var(--muted))]"
-              type="button"
-            >
-              GitHub
-            </button>
-            <button
-              className="rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-sm transition hover:bg-[rgb(var(--muted))]"
-              type="button"
-            >
-              login
-            </button>
-          </div>
-        </div>
-      </header>
+			{/* menu */}
+			<div className="flex items-center gap-2">
+				<button
+				className="rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-sm transition hover:bg-[rgb(var(--muted))]"
+				type="button"
+				>
+				GitHub
+				</button>
+				<button
+				className="rounded-lg border border-[rgb(var(--border))] px-3 py-2 text-sm transition hover:bg-[rgb(var(--muted))]"
+				type="button"
+				>
+				login
+				</button>
+			</div>
+			</div>
+		</header>
 
-      {/* Center */}
-      <section className="mx-auto w-full max-w-5xl px-6 flex-1 flex items-center">
-        <div className="w-full px-6 py-12">
-          <div className="mx-auto max-w-2xl text-center">
-            <p className="text-sm text-[rgb(var(--muted-foreground))]">
-              whalley score
-            </p>
+		{/* Center */}
+		<section className="mx-auto w-full max-w-5xl px-6 flex-1 flex items-center">
+			<div className="w-full px-6 py-12">
+			<div className="mx-auto max-w-2xl text-center">
+				<p className="text-sm text-[rgb(var(--muted-foreground))]">
+				whalley score
+				</p>
 
-            <h1 className="mt-4 text-4xl font-bold leading-tight sm:text-5xl">
-              Find Your Best <br /> Working &amp; Holiday!
-            </h1>
+				<h1 className="mt-4 text-4xl font-bold leading-tight sm:text-5xl">
+				Find Your Best <br /> Working &amp; Holiday!
+				</h1>
 
-            <p className="mt-4 text-sm leading-relaxed text-[rgb(var(--muted-foreground))]">
-              간단한 입력으로 나에게 맞는 워캉홀리데이 국가를 추천해요.
-            </p>
+				<p className="mt-4 text-sm leading-relaxed text-[rgb(var(--muted-foreground))]">
+				간단한 입력으로 나에게 맞는 워캉홀리데이 국가를 추천해요.
+				</p>
 
-            {/* keyword chips (유지) */}
-            <div className="mt-3 flex flex-wrap justify-center gap-2">
-              <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1 text-xs text-[rgb(var(--muted-foreground))]">
-                추천 국가
-              </span>
-              <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1 text-xs text-[rgb(var(--muted-foreground))]">
-                점수 계산
-              </span>
-              <span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1 text-xs text-[rgb(var(--muted-foreground))]">
-                지도에서 비교
-              </span>
-            </div>
+				{/* keyword chips (유지) */}
+				<div className="mt-3 flex flex-wrap justify-center gap-2">
+				<span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1 text-xs text-[rgb(var(--muted-foreground))]">
+					추천 국가
+				</span>
+				<span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1 text-xs text-[rgb(var(--muted-foreground))]">
+					점수 계산
+				</span>
+				<span className="rounded-full border border-[rgb(var(--border))] bg-[rgb(var(--card))] px-3 py-1 text-xs text-[rgb(var(--muted-foreground))]">
+					지도에서 비교
+				</span>
+				</div>
 
-            {/* CTA */}
-            <div className="mt-6 flex flex-col items-center justify-center gap-2">
-              <Link
-                href="/map"
-                className="
-                  inline-flex items-center justify-center
-                  rounded-xl bg-[rgb(var(--fg))]
-                  px-7 py-3 text-sm font-semibold
-                  text-[rgb(var(--bg))]
-                  transition
-                  hover:opacity-90
-                "
-              >
-                GET STARTED
-              </Link>
+				{/* CTA */}
+				<div className="mt-6 flex flex-col items-center justify-center gap-2">
+				<Link
+					href="/map"
+					className="
+					inline-flex items-center justify-center
+					rounded-xl bg-[rgb(var(--fg))]
+					px-7 py-3 text-sm font-semibold
+					text-[rgb(var(--bg))]
+					transition
+					hover:opacity-90
+					"
+				>
+					GET STARTED
+				</Link>
 
-              <p className="text-xs text-[rgb(var(--muted-foreground))]">
-                지도에서 추천 국가를 바로 확인해요
-              </p>
+				<p className="text-xs text-[rgb(var(--muted-foreground))]">
+					지도에서 추천 국가를 바로 확인해요
+				</p>
 
-              {/* ✅ 보조 CTA는 텍스트 링크로만 */}
-              <Link
-                href="/test"
-                className="mt-2 text-xs text-[rgb(var(--muted-foreground))] underline underline-offset-4 transition hover:text-fg"
-              >
-                내 점수 먼저 확인하기 →
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
+				{/* ✅ 보조 CTA는 텍스트 링크로만 */}
+				<Link
+					href="/test"
+					className="mt-2 text-xs text-[rgb(var(--muted-foreground))] underline underline-offset-4 transition hover:text-fg"
+				>
+					내 점수 먼저 확인하기 →
+				</Link>
+				</div>
+			</div>
+			</div>
+		</section>
 
-      {/* Footer */}
-      <footer className="mx-auto max-w-5xl px-6 pb-10 pt-6 text-xs text-[rgb(var(--muted-foreground))]">
-        © {new Date().getFullYear()} Whalley Score
-      </footer>
-    </main>
-  );
+		{/* Footer */}
+		<footer className="mx-auto max-w-5xl px-6 pb-10 pt-6 text-xs text-[rgb(var(--muted-foreground))]">
+			© {new Date().getFullYear()} Whalley Score
+		</footer>
+		</main>
+	);
 }

--- a/apps/web/src/shared/components/RecommendationsPanel.tsx
+++ b/apps/web/src/shared/components/RecommendationsPanel.tsx
@@ -1,0 +1,412 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+export type RecommendationItem = {
+  id: string;
+  country: string;
+  score: number;
+};
+
+type Props = {
+  items: RecommendationItem[];
+
+  /** desktop width */
+  desktopWidth: number;
+  setDesktopWidth: (w: number) => void;
+
+  /** desktop collapsed (only tab remains) */
+  desktopCollapsed: boolean;
+  setDesktopCollapsed: (v: boolean) => void;
+
+  /** mobile sheet height (px), 0 means hidden */
+  mobileHeight: number;
+  setMobileHeight: (h: number) => void;
+
+  /**
+   * Optional:
+   * If you want the panel to sit below a fixed header.
+   * (Default values match your AppShell: top-4 + h-12 + gap)
+   */
+  headerTopPx?: number; // default 16
+  headerHeightPx?: number; // default 48
+  gapPx?: number; // default 12
+};
+
+function clamp(n: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, n));
+}
+
+function useIsMobile(breakpointPx = 768) {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia(`(max-width: ${breakpointPx - 1}px)`);
+    const update = () => setIsMobile(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, [breakpointPx]);
+
+  return isMobile;
+}
+
+export default function RecommendationsPanel(props: Props) {
+  const {
+    items,
+    desktopWidth,
+    setDesktopWidth,
+    desktopCollapsed,
+    setDesktopCollapsed,
+    mobileHeight,
+    setMobileHeight,
+    headerTopPx = 16,
+    headerHeightPx = 48,
+    gapPx = 12,
+  } = props;
+
+  const isMobile = useIsMobile(768);
+
+  // ----- filters (MVP) -----
+  const [sort, setSort] = useState<"desc" | "asc">("desc");
+  const [minScore, setMinScore] = useState(0);
+  const [maxScore, setMaxScore] = useState(100);
+
+  const filtered = useMemo(() => {
+    const base = items.filter((x) => x.score >= minScore && x.score <= maxScore);
+    base.sort((a, b) => (sort === "desc" ? b.score - a.score : a.score - b.score));
+    return base;
+  }, [items, minScore, maxScore, sort]);
+
+  // =========================================================
+  // Desktop: resizable width
+  // =========================================================
+  const dragRef = useRef<{ startX: number; startW: number; dragging: boolean } | null>(null);
+
+  function onDesktopPointerDown(e: React.PointerEvent) {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    dragRef.current = { startX: e.clientX, startW: desktopWidth, dragging: true };
+  }
+  function onDesktopPointerMove(e: React.PointerEvent) {
+    if (!dragRef.current?.dragging) return;
+    const dx = dragRef.current.startX - e.clientX; // move left => bigger
+    const next = clamp(dragRef.current.startW + dx, 280, 520);
+    setDesktopWidth(next);
+  }
+  function onDesktopPointerUp(e: React.PointerEvent) {
+    if (!dragRef.current) return;
+    dragRef.current.dragging = false;
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {}
+  }
+
+  // =========================================================
+  // Mobile: bottom sheet drag + snap
+  // =========================================================
+  const sheetDragRef = useRef<{ startY: number; startH: number; dragging: boolean } | null>(null);
+  const didInitMobile = useRef(false);
+
+  const getSnapHeights = () => {
+    const vh = window.innerHeight;
+    return {
+      min: 0,
+      mid: Math.round(vh * 0.45),
+      max: Math.round(vh * 0.82),
+    };
+  };
+
+  // ✅ only first time on mobile -> open mid
+  useEffect(() => {
+    if (!isMobile) return;
+    if (didInitMobile.current) return;
+    didInitMobile.current = true;
+
+    if (mobileHeight === 0) {
+      const { mid } = getSnapHeights();
+      setMobileHeight(Math.min(mid, 420));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isMobile]);
+
+  function onSheetPointerDown(e: React.PointerEvent) {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    sheetDragRef.current = { startY: e.clientY, startH: mobileHeight, dragging: true };
+  }
+  function onSheetPointerMove(e: React.PointerEvent) {
+    if (!sheetDragRef.current?.dragging) return;
+    const dy = sheetDragRef.current.startY - e.clientY; // drag up => increase
+    const vh = window.innerHeight;
+    const next = clamp(sheetDragRef.current.startH + dy, 0, Math.round(vh * 0.9));
+    setMobileHeight(next);
+  }
+  function onSheetPointerUp(e: React.PointerEvent) {
+    if (!sheetDragRef.current) return;
+    sheetDragRef.current.dragging = false;
+
+    const { min, mid, max } = getSnapHeights();
+    const candidates = [min, mid, max];
+    const nearest = candidates.reduce((best, cur) =>
+      Math.abs(cur - mobileHeight) < Math.abs(best - mobileHeight) ? cur : best
+    );
+    setMobileHeight(nearest);
+
+    try {
+      (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
+    } catch {}
+  }
+
+  // ----- shared “glass card” classes -----
+  const glass =
+    "rounded-2xl border border-[rgb(var(--border))] bg-bg/70 backdrop-blur-md shadow-sm";
+
+  // ============================
+  // Mobile render
+  // ============================
+  if (isMobile) {
+    const isHidden = mobileHeight <= 0;
+
+    return (
+      <div className="pointer-events-none fixed inset-x-0 bottom-0 z-30">
+        {/* reopen when hidden */}
+        {isHidden && (
+          <div className="pointer-events-auto mx-auto mb-4 w-fit">
+            <button
+              type="button"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                const { mid } = getSnapHeights();
+                setMobileHeight(Math.min(mid, 420));
+              }}
+              className={`${glass} px-4 py-2 text-sm`}
+            >
+              추천 열기 ↑
+            </button>
+          </div>
+        )}
+
+        <div
+          className={["pointer-events-auto mx-auto w-full max-w-screen-sm", glass].join(" ")}
+          style={{ height: mobileHeight }}
+        >
+          {/* Drag handle area ONLY */}
+          <div
+            className="flex items-center justify-between px-4 pt-3 pb-2 select-none"
+            onPointerDown={onSheetPointerDown}
+            onPointerMove={onSheetPointerMove}
+            onPointerUp={onSheetPointerUp}
+          >
+            <div className="flex items-center gap-2">
+              <div className="h-1.5 w-10 rounded-full bg-[rgb(var(--border))]" />
+              <span className="text-sm font-semibold">Recommendations</span>
+            </div>
+
+            {/* ✅ stopPropagation so it won't trigger drag/snap */}
+            <button
+              type="button"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.stopPropagation();
+                setMobileHeight(0);
+              }}
+              className="rounded-lg px-2 py-1 text-sm hover:bg-[rgb(var(--muted))]"
+            >
+              닫기
+            </button>
+          </div>
+
+          {/* Filters */}
+          <div className="px-4 pb-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <select
+                value={sort}
+                onChange={(e) => setSort(e.target.value as "asc" | "desc")}
+                className="rounded-xl border border-[rgb(var(--border))] bg-bg px-3 py-2 text-sm"
+              >
+                <option value="desc">점수 높은순</option>
+                <option value="asc">점수 낮은순</option>
+              </select>
+
+              <div className="flex items-center gap-2 rounded-xl border border-[rgb(var(--border))] bg-bg px-3 py-2">
+                <span className="text-xs text-[rgb(var(--muted-foreground))]">Min</span>
+                <input
+                  type="number"
+                  value={minScore}
+                  onChange={(e) => setMinScore(clamp(Number(e.target.value || 0), 0, 100))}
+                  className="w-14 bg-transparent text-sm outline-none"
+                />
+              </div>
+
+              <div className="flex items-center gap-2 rounded-xl border border-[rgb(var(--border))] bg-bg px-3 py-2">
+                <span className="text-xs text-[rgb(var(--muted-foreground))]">Max</span>
+                <input
+                  type="number"
+                  value={maxScore}
+                  onChange={(e) => setMaxScore(clamp(Number(e.target.value || 100), 0, 100))}
+                  className="w-14 bg-transparent text-sm outline-none"
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* List scrolls */}
+          <div className="h-[calc(100%-104px)] overflow-auto px-4 pb-4">
+            <div className="space-y-3">
+              {filtered.map((x) => (
+                <button
+                  key={x.id}
+                  type="button"
+                  className="w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3 text-left transition hover:bg-[rgb(var(--muted))]"
+                >
+                  <div className="flex items-center justify-between">
+                    <div className="font-medium">{x.country}</div>
+                    <div className="text-sm font-semibold text-[rgb(var(--primary))]">
+                      {x.score}
+                    </div>
+                  </div>
+                  <div className="mt-1 text-xs text-[rgb(var(--muted-foreground))]">
+                    Score based on your inputs (placeholder)
+                  </div>
+                </button>
+              ))}
+
+              {filtered.length === 0 && (
+                <div className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4 text-sm text-[rgb(var(--muted-foreground))]">
+                  조건에 맞는 국가가 없어요. 필터를 조정해보세요.
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ============================
+  // Desktop render (fixed overlay)
+  // ============================
+  const top = `calc(${headerTopPx}px + ${headerHeightPx}px + ${gapPx}px)`;
+  const bottom = `16px`;
+  const collapsedW = 32; // ✅ clickable width
+
+  return (
+    <aside
+      className={["fixed right-4 z-30", glass, "overflow-hidden"].join(" ")}
+      style={{
+        top,
+        bottom,
+        width: desktopCollapsed ? collapsedW : desktopWidth,
+      }}
+    >
+      {desktopCollapsed ? (
+        <div className="flex h-full items-center justify-center">
+          <button
+            type="button"
+            onClick={() => setDesktopCollapsed(false)}
+            className="rounded-xl border border-[rgb(var(--border))] bg-bg/70 px-2 py-2 text-sm hover:bg-[rgb(var(--muted))]"
+            aria-label="Expand recommendations"
+          >
+            ←
+          </button>
+        </div>
+      ) : (
+        <>
+          {/* Drag handle */}
+          <div
+            className="absolute left-0 top-0 h-full w-2 cursor-col-resize"
+            onPointerDown={onDesktopPointerDown}
+            onPointerMove={onDesktopPointerMove}
+            onPointerUp={onDesktopPointerUp}
+            role="separator"
+            aria-label="Resize recommendations panel"
+          />
+
+          <div className="flex h-full flex-col">
+            {/* Header */}
+            <div className="flex items-center justify-between px-4 py-3">
+              <div>
+                <div className="text-sm font-semibold">Recommendations</div>
+                <div className="text-xs text-[rgb(var(--muted-foreground))]">
+                  Sort & filter results
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setDesktopCollapsed(true)}
+                className="rounded-lg px-3 py-2 text-sm hover:bg-[rgb(var(--muted))]"
+                aria-label="Collapse recommendations"
+              >
+                →
+              </button>
+            </div>
+
+            {/* Filters */}
+            <div className="px-4 pb-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <select
+                  value={sort}
+                  onChange={(e) => setSort(e.target.value as "asc" | "desc")}
+                  className="rounded-xl border border-[rgb(var(--border))] bg-bg px-3 py-2 text-sm"
+                >
+                  <option value="desc">점수 높은순</option>
+                  <option value="asc">점수 낮은순</option>
+                </select>
+
+                <div className="flex items-center gap-2 rounded-xl border border-[rgb(var(--border))] bg-bg px-3 py-2">
+                  <span className="text-xs text-[rgb(var(--muted-foreground))]">Min</span>
+                  <input
+                    type="number"
+                    value={minScore}
+                    onChange={(e) => setMinScore(clamp(Number(e.target.value || 0), 0, 100))}
+                    className="w-14 bg-transparent text-sm outline-none"
+                  />
+                </div>
+
+                <div className="flex items-center gap-2 rounded-xl border border-[rgb(var(--border))] bg-bg px-3 py-2">
+                  <span className="text-xs text-[rgb(var(--muted-foreground))]">Max</span>
+                  <input
+                    type="number"
+                    value={maxScore}
+                    onChange={(e) => setMaxScore(clamp(Number(e.target.value || 100), 0, 100))}
+                    className="w-14 bg-transparent text-sm outline-none"
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* List */}
+            <div className="flex-1 overflow-auto px-4 pb-4">
+              <div className="space-y-3">
+                {filtered.map((x) => (
+                  <button
+                    key={x.id}
+                    type="button"
+                    className="w-full rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-3 text-left transition hover:bg-[rgb(var(--muted))]"
+                  >
+                    <div className="flex items-center justify-between">
+                      <div className="font-medium">{x.country}</div>
+                      <div className="text-sm font-semibold text-[rgb(var(--primary))]">
+                        {x.score}
+                      </div>
+                    </div>
+                    <div className="mt-1 text-xs text-[rgb(var(--muted-foreground))]">
+                      Score based on your inputs (placeholder)
+                    </div>
+                  </button>
+                ))}
+
+                {filtered.length === 0 && (
+                  <div className="rounded-xl border border-[rgb(var(--border))] bg-[rgb(var(--card))] p-4 text-sm text-[rgb(var(--muted-foreground))]">
+                    조건에 맞는 국가가 없어요. 필터를 조정해보세요.
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/apps/web/src/shared/ui/app-shell/AppShell.tsx
+++ b/apps/web/src/shared/ui/app-shell/AppShell.tsx
@@ -1,136 +1,98 @@
 "use client";
 
-/**
- * AppShell = (app) common layout
- * - Header: fixed top
- * - Sidebar: 데스크톱 좌측 고정 + 접기 가능
- * - Mobile Drawer: 모바일에서 햄버거로 열기
- * - children: 각 페이지(page.tsx)가 이 자리로 들어온다
-*/
-
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo, useState } from "react";
+import { Montserrat_Alternates } from "next/font/google";
 
 type NavItem = { href: string; label: string };
 
+const montserratAlternates = Montserrat_Alternates({
+  subsets: ["latin"],
+  weight: ["400", "600", "700"],
+});
+
 export default function AppShell({ children }: { children: React.ReactNode }) {
-  	const pathname = usePathname();
+  const pathname = usePathname();
+  const isMap = pathname?.startsWith("/map");
 
-  	// desktop sidebar
-  	const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
 
- 	// mobile drawer
- 	const [mobileOpen, setMobileOpen] = useState(false);
+  const navItems: NavItem[] = useMemo(
+    () => [
+      { href: "/map", label: "Map" },
+      { href: "/profile", label: "Profile" },
+      { href: "/list", label: "List" },
+      { href: "/detail", label: "Detail" },
+      { href: "/test", label: "Test" },
+    ],
+    []
+  );
 
-  	// sidebar menu
-  	const navItems: NavItem[] = useMemo(
-		() => [
-			{ href: "/map", label: "Map" },
-			{ href: "/profile", label: "Profile" },
-			{ href: "/list", label: "List" },
-			{ href: "/detail", label: "Detail" },
-			{ href: "/test", label: "Test" },
-		],
-		[]
-  	);
+  const Sidebar = () => (
+    <aside
+      className={[
+        "fixed left-4 z-30",
+        // 헤더 아래로 정확히 떨어지게: top을 '헤더+여백'로 계산
+        "top-[calc(var(--ws-header-top)+var(--ws-header-h)+12px)]",
+        collapsed ? "w-16" : "w-40",
+        "rounded-2xl border border-[rgb(var(--border))] bg-bg/70 backdrop-blur-md shadow-sm",
+        "transition-all",
+      ].join(" ")}
+    >
+      <div className="flex items-center justify-between px-3 py-2">
+        {!collapsed && <span className="text-sm font-semibold">Menu</span>}
+        <button
+          onClick={() => setCollapsed((v) => !v)}
+          className="rounded-lg px-2 py-1 text-sm hover:bg-[rgb(var(--muted))]"
+          type="button"
+        >
+          {collapsed ? "→" : "←"}
+        </button>
+      </div>
 
-  	// sidebar UI (reuse in desktop/mobile)
-	const Sidebar = ({ mode }: { mode: "desktop" | "mobile" }) => (
-		<nav className="h-full p-2">
-			<div className="space-y-1">
-				{navItems.map((item) => {
-					const active =
-						pathname === item.href || pathname?.startsWith(item.href + "/");
-					return (
-						<Link
-							key={item.href}
-							href={item.href}
-							onClick={() => mode === "mobile" && setMobileOpen(false)} 
-							className={[
-								"flex items-center rounded-xl px-3 py-2 text-sm transition",
-								active
-								? "bg-black text-white"
-								: "text-neutral-800 hover:bg-neutral-100 bg-bg",
-								collapsed && mode === "desktop" ? "justify-center px-2" : "gap-3",
-							].join(" ")}
-							aria-current={active ? "page" : undefined}>
-							{/* icon */}
-							<span className="inline-block h-2 w-2 rounded-full bg-current opacity-70" />
-							{/* hide */}
-							{!(collapsed && mode === "desktop") && <span>{item.label}</span>}
-						</Link>
-					);
-				})}
-     		</div>
-    	</nav>
-  	);
+      <nav className="space-y-1 p-2">
+        {navItems.map((item) => {
+          const active = pathname === item.href || pathname?.startsWith(item.href + "/");
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={[
+                "flex items-center rounded-xl px-3 py-2 text-sm transition",
+                active ? "bg-black text-white" : "hover:bg-[rgb(var(--muted))]",
+                collapsed ? "justify-center" : "gap-3",
+              ].join(" ")}
+            >
+              <span className="h-2 w-2 rounded-full bg-current opacity-70" />
+              {!collapsed && item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
 
-	return (
-		<div className="min-h-dvh bg-bg text-neutral-900">
-		{/* Header */}
-		<header className="sticky top-0 z-40 h-14 border-b bg-bg/80 backdrop-blur">
-			<div className="mx-auto flex h-full max-w-screen-2xl items-center gap-3 px-4">
-				{/* mobile menu */}
-				<button
-					className="md:hidden rounded-lg px-3 py-2 hover:bg-neutral-100"
-					onClick={() => setMobileOpen(true)}
-					aria-label="Open navigation">
-					☰
-				</button>
-				{/* logo and title */}
-				<Link href="/map" className="flex items-center gap-2 font-semibold">
-					<div className="h-7 w-7 rounded-xl bg-black" aria-hidden />
-					<span className="hidden sm:inline">Whalley Score</span>
-				</Link>
-          	<div className="flex-1" />
+  return (
+    // 헤더 위치/높이를 변수로 고정 (여기만 바꾸면 전체 overlay가 같이 맞춰짐)
+    <div className="relative min-h-dvh bg-bg text-neutral-900 [--ws-header-top:16px] [--ws-header-h:48px]">
+      {/* Header (overlay) */}
+      <header className="fixed left-0 right-0 z-40 top-[var(--ws-header-top)]">
+        <div className="mx-auto max-w-screen-2xl px-4">
+          <div className="h-[var(--ws-header-h)] flex items-center gap-3 rounded-full border border-[rgb(var(--border))] bg-bg/60 backdrop-blur-md shadow-sm px-4">
+            <Link href="/map" className="flex items-center gap-2 font-semibold">
+              <div className="h-7 w-7 rounded-xl bg-black" />
+              <span className={montserratAlternates.className}>whalley score</span>
+            </Link>
+          </div>
+        </div>
+      </header>
 
-				{/* close desktop sidebar */}
-				<button
-					className="hidden md:inline-flex rounded-lg px-3 py-2 hover:bg-neutral-100"
-					onClick={() => setCollapsed((v) => !v)}
-					aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
-					{collapsed ? "→" : "←"}
-				</button>
-        	</div>
-     	</header>
+      {/* Sidebar: 지도 페이지에서만 띄울지, 전체 페이지 띄울지 선택 */}
+      {<Sidebar />}
 
-		{/* Mobile Drawer */}
-		{mobileOpen && (
-			<div className="fixed inset-0 z-50 md:hidden">
-			<div
-				className="absolute inset-0 bg-black/40"
-				onClick={() => setMobileOpen(false)}
-			/>
-			<aside className="absolute left-0 top-0 h-full w-72 bg-bg border-r">
-				<div className="h-14 border-b px-4 flex items-center justify-between">
-				<span className="font-semibold">Whalley Score</span>
-				<button
-					className="rounded-lg px-3 py-2 hover:bg-neutral-100"
-					onClick={() => setMobileOpen(false)}
-					aria-label="Close navigation"
-				>
-					✕
-				</button>
-				</div>
-				<Sidebar mode="mobile" />
-			</aside>
-			</div>
-		)}
-
-		{/* Desktop: Sidebar + Content */}
-		<div className="mx-auto grid max-w-screen-2xl md:grid-cols-[auto_1fr]">
-			{/* desktop sidebar */}
-			<aside
-			className={[
-				"hidden md:block border-r bg-bg",
-				collapsed ? "w-16" : "w-64",
-			].join(" ")}
-			>
-			<Sidebar mode="desktop" />
-			</aside>
-			<div className="min-h-[calc(100dvh-56px)] w-full">{children}</div>
-		</div>
-		</div>
-	);
+      {/* Content: 패딩 없음! (지도는 헤더 뒤까지 꽉 참) */}
+      <main className="min-h-dvh">{children}</main>
+    </div>
+  );
 }


### PR DESCRIPTION
close #10 

## What’s included
This PR implements the complete Map page layout and interaction layer.

### Map Layout
- Full-height map rendering behind the fixed header
- No padding applied globally (handled per-page)

### Recommendations Panel
**Desktop**
- Fixed overlay panel on the right
- Draggable width resize
- Collapsible with persistent reopen handle

**Mobile**
- Bottom sheet UI
- Drag to expand/collapse
- Snap points for usability
- Internal scroll for content

### Filtering
- Sort by score (asc / desc)
- Min / Max score filtering
- Placeholder data only (API integration later)

## Why
This establishes the UI/UX foundation for the Map experience before integrating
AI-based recommendation logic on the backend.

## Out of Scope
- Backend / AI scoring logic
- Persistent state or URL sync


## Screenshots
<img width="1133" height="659" alt="Screenshot 2026-01-05 at 8 26 49 PM" src="https://github.com/user-attachments/assets/e7a313d7-c48f-49f8-89d3-f0ee6dae7235" />
<img width="1123" height="659" alt="Screenshot 2026-01-05 at 8 27 06 PM" src="https://github.com/user-attachments/assets/9241d3fb-e8ae-4e80-a4c2-527515778641" />
<img width="501" height="657" alt="Screenshot 2026-01-05 at 8 27 19 PM" src="https://github.com/user-attachments/assets/45930be2-5970-4ba5-b386-71fff9e1856b" />
<img width="501" height="660" alt="Screenshot 2026-01-05 at 8 27 37 PM" src="https://github.com/user-attachments/assets/7ec39e03-64eb-4e00-8936-a65952827186" />
